### PR TITLE
this should be merged with issue 580 in augur repo.

### DIFF
--- a/src/modules/market/components/basics.jsx
+++ b/src/modules/market/components/basics.jsx
@@ -17,7 +17,7 @@ const Basics = (p) => (
 		<ul className="properties">
 			{!!p.endDate &&
 				<li className="property end-date">
-					<span className="property-label">{(p.endDate && p.endDate.value < new Date()) ? 'ended' : 'ends'}</span>
+					<span className="property-label">{p.endDateLabel}</span>
 					<ValueDenomination className="property-value" {...p.endDate} />
 				</li>
 			}

--- a/src/selectors/markets.js
+++ b/src/selectors/markets.js
@@ -30,6 +30,7 @@ function makeMarkets(numMarkets = 25) {
 			type: types[randomInt(0, types.length - 1)],
 			description: `Will the dwerps achieve a mwerp by the end of zwerp ${(index + 1)}?`,
 			endDate: { formatted: '12/12/2017' },
+			endDateLabel: (new Date('12/12/2017') < new Date()) ? 'ended' : 'ends',
 			tradingFeePercent: makeNumber(randomInt(1, 10), '%', true),
 			makerFeePercent: makeNumber(randomInt(0, 100), '%', true),
 			volume: makeNumber(randomInt(0, 10000), 'Shares', true),

--- a/test/assertions/market.js
+++ b/test/assertions/market.js
@@ -8,6 +8,7 @@ import numberShape from '../../test/assertions/common/numberShape';
 //      type: String,
 //      description: String,
 //      endDate: Object,
+//			endDateLabel: String,
 //      tradingFeePercent: Object,
 //      volume: Object,
 //      isOpen: Boolean,
@@ -37,6 +38,9 @@ function marketAssertion(actual) {
 
 	assert.isDefined(actual.endDate, `market.endDate isn't defined`);
 	assert.isObject(actual.endDate, `market.endDate isn't an object`);
+
+	assert.isDefined(actual.endDateLabel, `market.endDateLabel isn't defined`);
+	assert.isString(actual.endDateLabel, `market.endDateLabel isn't an string`);
 
 	assert.isDefined(actual.tradingFeePercent, `market.tradingFeePercent isn't defined`);
 	assert.isObject(actual.tradingFeePercent, `market.tradingFeePercent isn't an object`);


### PR DESCRIPTION
added endDateLabel to market selectors object and replaced logic in basics component to use endDateLabel for "ends" or "ended" based on endDate. Updated assertions. Updated mock market selectors.
