### PR TITLE
adjusted the criteria for `shouldComponentUpdate`

### DIFF
--- a/src/modules/market/components/chart.jsx
+++ b/src/modules/market/components/chart.jsx
@@ -1,5 +1,4 @@
 import React, { Component, PropTypes } from 'react';
-import shouldComponentUpdatePure from '../../../utils/should-component-update-pure';
 import ReactHighcharts from 'react-highcharts';
 
 export default class Chart extends Component {
@@ -7,9 +6,10 @@ export default class Chart extends Component {
 		series: PropTypes.array
 	};
 
-	constructor(props) {
-		super(props);
-		this.shouldComponentUpdate = shouldComponentUpdatePure;
+	shouldComponentUpdate(nextProps) {
+		if (nextProps.series.length === this.props.series.length) return false;
+
+		return true;
 	}
 
 	render() {


### PR DESCRIPTION
This PR resolves this specific issue: `Clicking on a data input field of trade panel refreshes the chart each time` from issue [#731](https://github.com/AugurProject/augur/issues/731).
