### PR TITLE
Fix to positions scalar outcomes

### DIFF
--- a/src/modules/balances/components/balances-page.jsx
+++ b/src/modules/balances/components/balances-page.jsx
@@ -1,35 +1,27 @@
-import React, { Component } from 'react';
+import React from 'react';
 import classnames from 'classnames';
 import SiteHeader from '../../site/components/site-header';
 import SiteFooter from '../../site/components/site-footer';
 
-export default class BalancesPage extends Component {
-	static propTypes = {
-		className: React.PropTypes.string
-	};
+const BalancesPage = (p) => (
+	<main className={classnames('page account')}>
+		<SiteHeader {...p.siteHeader} />
+		<header className="page-header">
+			<span className="big-line">Balances</span>
+		</header>
 
-	constructor(props) {
-		super(props);
-	}
+		<section className="page-content">
+			<div className="l-container">
+				<div className="balances-section">
+				</div>
+			</div>
+		</section>
+		<SiteFooter />
+	</main>
+);
 
-	render() {
-		const p = this.props;
+BalancesPage.propTypes = {
+	className: React.PropTypes.string
+};
 
-		return (
-			<main className={classnames('page account')}>
-				<SiteHeader {...p.siteHeader} />
-				<header className="page-header">
-					<span className="big-line">Balances</span>
-				</header>
-
-				<section className="page-content">
-					<div className="l-container">
-						<div className="balances-section">
-						</div>
-					</div>
-				</section>
-				<SiteFooter />
-			</main>
-		);
-	}
-}
+export default BalancesPage;

--- a/src/modules/my-positions/components/my-position.jsx
+++ b/src/modules/my-positions/components/my-position.jsx
@@ -1,10 +1,14 @@
 import React from 'react';
 import ValueDenomination from '../../common/components/value-denomination';
+import { SCALAR } from '../../markets/constants/market-types';
 
 const Position = (p) => (
 	<div className="position">
 		<div className="position-group main-group">
-			<span className="position-name">{p.name}</span>
+			{p.type === SCALAR ?
+				<span className="position-name">{p.lastPricePercent.rounded}</span> :
+				<span className="position-name">{p.name}</span>
+			}
 			<ValueDenomination {...p.qtyShares} />
 			<ValueDenomination
 				{...p.gainPercent}
@@ -45,10 +49,12 @@ const Position = (p) => (
 
 Position.propTypes = {
 	name: React.PropTypes.string,
+	type: React.PropTypes.string,
 	qtyShares: React.PropTypes.object,
 	totalValue: React.PropTypes.object,
 	gainPercent: React.PropTypes.object,
 	lastPrice: React.PropTypes.object,
+	lastPricePercent: React.PropTypes.object,
 	purchasePrice: React.PropTypes.object,
 	shareChange: React.PropTypes.object,
 	totalCost: React.PropTypes.object,

--- a/src/modules/my-positions/components/my-positions.jsx
+++ b/src/modules/my-positions/components/my-positions.jsx
@@ -3,9 +3,10 @@ import Position from './my-position';
 
 const Positions = (p) => (
 	<section className="positions-list">
-			{(p.outcomes || []).map(outcome =>
+			{(p.outcomes || []).map(outcome => (
 				<Position
 					key={outcome.id}
+					type={p.type}
 					{...outcome}
 					{...outcome.position}
 				/>
@@ -15,6 +16,7 @@ const Positions = (p) => (
 
 Positions.propTypes = {
 	className: React.PropTypes.string,
+	type: React.PropTypes.string,
 	outcomes: React.PropTypes.array
 };
 export default Positions;

--- a/src/modules/my-positions/components/my-positions.jsx
+++ b/src/modules/my-positions/components/my-positions.jsx
@@ -3,14 +3,14 @@ import Position from './my-position';
 
 const Positions = (p) => (
 	<section className="positions-list">
-			{(p.outcomes || []).map(outcome => (
-				<Position
-					key={outcome.id}
-					type={p.type}
-					{...outcome}
-					{...outcome.position}
-				/>
-			)}
+		{(p.outcomes || []).map(outcome =>
+			<Position
+				key={outcome.id}
+				type={p.type}
+				{...outcome}
+				{...outcome.position}
+			/>
+		)}
 	</section>
 );
 

--- a/src/modules/portfolio/components/positions.jsx
+++ b/src/modules/portfolio/components/positions.jsx
@@ -11,6 +11,7 @@ const PortfolioPositions = (p) => (
 					{!!market.myPositionOutcomes && !!market.myPositionOutcomes.length &&
 						<Positions
 							className="page-content positions-content"
+							type={market.type}
 							outcomes={market.myPositionOutcomes}
 						/>
 					}


### PR DESCRIPTION
This is a fix to the scalar outcomes display in positions.

Previously the outcome ‘name’ was blank, now the `lastPricePercent` is displayed (same as trade row).
